### PR TITLE
fixes assert segfault (debug only) when schema has no attributes

### DIFF
--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -15382,7 +15382,6 @@ const DWORD * CSphIndex_VLN::FindDocinfo ( SphDocID_t uDocID ) const
 
 	assert ( m_tSettings.m_eDocinfo==SPH_DOCINFO_EXTERN );
 	assert ( !m_tAttr.IsEmpty() );
-	assert ( m_tSchema.GetAttrsCount() );
 
 	int iStride = DOCINFO_IDSIZE + m_tSchema.GetRowSize();
 	int64_t iStart = 0;


### PR DESCRIPTION
Hello, Upstream!

When Sphinx is built with debug I got this segfault (when searching), because my index has no attributes.
So I believe it is not a useful check.
