### PR TITLE
Call suggests

### DIFF
--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -15737,7 +15737,7 @@ void HandleMysqlCallKeywords ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 	tOut.Eof();
 }
 
-void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
+void HandleMysqlCallExpansions ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 {
 	CSphString sError;
 
@@ -15747,7 +15747,7 @@ void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		|| tStmt.m_dInsertValues[0].m_iType!=TOK_QUOTED_STRING
 		|| tStmt.m_dInsertValues[1].m_iType!=TOK_QUOTED_STRING )
 	{
-		tOut.Error ( tStmt.m_sStmt, "bad arguments in SUGGESTS() call: (string, string ...) needed" );
+		tOut.Error ( tStmt.m_sStmt, "bad arguments in EXPANSIONS() call: (string, string ...) needed" );
 		return;
 	}
 
@@ -15757,7 +15757,7 @@ void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		SqlInsert_t & tVar = tStmt.m_dInsertValues[2];
 		if ( tVar.m_iType!=TOK_CONST_INT )
 		{
-			tOut.Error ( tStmt.m_sStmt, "bad arguments in SUGGESTS() call: third one must be INT" );
+			tOut.Error ( tStmt.m_sStmt, "bad arguments in EXPANSIONS() call: third one must be INT" );
 			return;
 		}
 		iLimit = tVar.m_iVal;
@@ -15770,13 +15770,13 @@ void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		tQuery.m_sQuery = tStmt.m_dInsertValues[0].m_sVal;
 
 		CSphVector<CSphKeywordInfo> dKeywords;
-		bool bRes = pServed->m_pIndex->GetSuggests ( dKeywords, &tQuery, &sError );
+		bool bRes = pServed->m_pIndex->GetExpansions ( dKeywords, &tQuery, &sError );
 		pServed->Unlock ();
 
 		// :REFACTOR:
 		if ( !bRes )
 		{
-			sError.SetSprintf ( "suggest extraction failed: %s", sError.cstr() );
+			sError.SetSprintf ( "expansion failed: %s", sError.cstr() );
 			tOut.Error ( tStmt.m_sStmt, sError.cstr() );
 			return;
 		}
@@ -15813,7 +15813,7 @@ void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		sphSort ( dKeywords.Begin(), dKeywords.GetLength(), bind ( &CSphKeywordInfo::m_iHits ) );
 
 		tOut.HeadBegin ( 3 );
-		tOut.HeadColumn("suggest");
+		tOut.HeadColumn("expansion");
 		tOut.HeadColumn("docs");
 		tOut.HeadColumn("hits");
 		tOut.HeadEnd ();
@@ -18631,10 +18631,10 @@ public:
 			{
 				StatCountCommand ( SEARCHD_COMMAND_KEYWORDS );
 				HandleMysqlCallKeywords ( tOut, *pStmt );
-			} else if ( pStmt->m_sCallProc=="SUGGESTS" )
+			} else if ( pStmt->m_sCallProc=="EXPANSIONS" )
 			{
-				//StatCountCommand ( SEARCHD_COMMAND_SUGGESTS );
-				HandleMysqlCallSuggests ( tOut, *pStmt );
+				//StatCountCommand ( SEARCHD_COMMAND_EXPANSIONS );
+				HandleMysqlCallExpansions ( tOut, *pStmt );
 			} else
 			{
 				m_sError.SetSprintf ( "no such builtin procedure %s", pStmt->m_sCallProc.cstr() );

--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -15651,6 +15651,27 @@ void HandleMysqlCallSnippets ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 	tOut.Eof();
 }
 
+static const ServedIndex_t * GetCallIndex ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt, CSphString & sError )
+{
+	const ServedIndex_t * pServed = g_pLocalIndexes->GetRlockedEntry ( tStmt.m_dInsertValues[1].m_sVal );
+	if ( !pServed || !pServed->m_bEnabled || !pServed->m_pIndex )
+	{
+		if ( pServed )
+			pServed->Unlock();
+
+		pServed = g_pTemplateIndexes->GetRlockedEntry ( tStmt.m_dInsertValues[1].m_sVal );
+		if ( !pServed || !pServed->m_bEnabled || !pServed->m_pIndex )
+		{
+			sError.SetSprintf ( "no such index %s", tStmt.m_dInsertValues[1].m_sVal.cstr() );
+			tOut.Error ( tStmt.m_sStmt, sError.cstr() );
+			if ( pServed )
+				pServed->Unlock();
+			pServed = NULL;
+		}
+	}
+
+	return pServed;
+}
 
 void HandleMysqlCallKeywords ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 {
@@ -15668,22 +15689,9 @@ void HandleMysqlCallKeywords ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		return;
 	}
 
-	const ServedIndex_t * pServed = g_pLocalIndexes->GetRlockedEntry ( tStmt.m_dInsertValues[1].m_sVal );
-	if ( !pServed || !pServed->m_bEnabled || !pServed->m_pIndex )
-	{
-		if ( pServed )
-			pServed->Unlock();
-
-		pServed = g_pTemplateIndexes->GetRlockedEntry ( tStmt.m_dInsertValues[1].m_sVal );
-		if ( !pServed || !pServed->m_bEnabled || !pServed->m_pIndex )
-		{
-			sError.SetSprintf ( "no such index %s", tStmt.m_dInsertValues[1].m_sVal.cstr() );
-			tOut.Error ( tStmt.m_sStmt, sError.cstr() );
-			if ( pServed )
-				pServed->Unlock();
-			return;
-		}
-	}
+	const ServedIndex_t * pServed = GetCallIndex ( tOut, tStmt, sError );
+	if ( !pServed )
+		return;
 
 	CSphVector<CSphKeywordInfo> dKeywords;
 	bool bStats = ( iArgs==3 && tStmt.m_dInsertValues[2].m_iVal!=0 );
@@ -15727,6 +15735,41 @@ void HandleMysqlCallKeywords ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		tOut.Commit();
 	}
 	tOut.Eof();
+}
+
+void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
+{
+	CSphString sError;
+
+	// string query, string index
+	int iArgs = tStmt.m_dInsertValues.GetLength();
+	if ( iArgs != 2
+		|| tStmt.m_dInsertValues[0].m_iType!=TOK_QUOTED_STRING
+		|| tStmt.m_dInsertValues[1].m_iType!=TOK_QUOTED_STRING )
+	{
+		tOut.Error ( tStmt.m_sStmt, "bad argument count or types in SUGGESTS() call" );
+		return;
+	}
+
+	const ServedIndex_t * pServed = GetCallIndex ( tOut, tStmt, sError );
+	if ( pServed )
+	{
+		const char * sQuery = tStmt.m_dInsertValues[0].m_sVal.cstr();
+
+		// :TODO:
+
+		pServed->Unlock ();
+
+		tOut.HeadBegin ( 3 );
+		tOut.HeadColumn("suggest");
+		tOut.HeadColumn("docs");
+		tOut.HeadColumn("hits");
+		tOut.HeadEnd ();
+
+		// :TODO:
+
+		tOut.Eof ();
+	}
 }
 
 
@@ -18523,6 +18566,10 @@ public:
 			{
 				StatCountCommand ( SEARCHD_COMMAND_KEYWORDS );
 				HandleMysqlCallKeywords ( tOut, *pStmt );
+			} else if ( pStmt->m_sCallProc=="SUGGESTS" )
+			{
+				//StatCountCommand ( SEARCHD_COMMAND_SUGGESTS );
+				HandleMysqlCallSuggests ( tOut, *pStmt );
 			} else
 			{
 				m_sError.SetSprintf ( "no such builtin procedure %s", pStmt->m_sCallProc.cstr() );

--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -15775,7 +15775,17 @@ void HandleMysqlCallSuggests ( SqlRowBuffer_c & tOut, SqlStmt_t & tStmt )
 		tOut.HeadColumn("hits");
 		tOut.HeadEnd ();
 
-		// :TODO:
+		char sBuf[16];
+		ARRAY_FOREACH ( i, dKeywords )
+		{
+			tOut.PutString ( dKeywords[i].m_sNormalized.cstr() );
+			snprintf ( sBuf, sizeof(sBuf), "%d", dKeywords[i].m_iDocs );
+			tOut.PutString ( sBuf );
+			snprintf ( sBuf, sizeof(sBuf), "%d", dKeywords[i].m_iHits );
+			tOut.PutString ( sBuf );
+
+			tOut.Commit();
+		}
 
 		tOut.Eof ();
 	}

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -1551,7 +1551,7 @@ public:
 	virtual bool				GetKeywords ( CSphVector <CSphKeywordInfo> & dKeywords, const char * szQuery, bool bGetStats, CSphString * pError ) const;
 	template <class Qword> bool	DoGetKeywords ( CSphVector <CSphKeywordInfo> & dKeywords, const char * szQuery, bool bGetStats, bool bFillOnly, CSphString * pError ) const;
 	virtual bool 				FillKeywords ( CSphVector <CSphKeywordInfo> & dKeywords ) const;
-	virtual bool				GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError );
+	virtual bool				GetExpansions ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError );
 
 	virtual bool				Merge ( CSphIndex * pSource, const CSphVector<CSphFilterSettings> & dFilters, bool bMergeKillLists );
 
@@ -18182,7 +18182,7 @@ bool sphCheckParsedQuery ( bool & bParsed, XQQuery_t & tParsed, CSphString * pEr
 	return bParsed;
 }
 
-bool CSphIndex_VLN::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError )
+bool CSphIndex_VLN::GetExpansions ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError )
 {
 	// :REFACTOR:
 
@@ -18208,14 +18208,6 @@ bool CSphIndex_VLN::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, cons
 	bool bRes = sphParseExtendedQuery ( tParsed, (const char*)sModifiedQuery, pQuery, m_pQueryTokenizer, &m_tSchema, pDict, m_tSettings );
 	if ( sphCheckParsedQuery ( bRes, tParsed, pError ) )
 	{
-		// :REFACTOR:
-
-		// this should be after keyword expansion
-		if ( m_tSettings.m_uAotFilterMask )
-			TransformAotFilter ( tParsed.m_pRoot, pDict->GetWordforms(), m_tSettings );
-
-		// :REFACTOR: end
-
 		CSphQueryResultMeta tResults;
 		tParsed.m_pRoot = ExpandPrefix ( tParsed.m_pRoot, &tResults, NULL, &dKeywords );
 	}

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -18608,7 +18608,7 @@ XQNode_t * sphExpandXQNode ( XQNode_t * pNode, ExpansionContext_t & tCtx )
 		return pNode;
 
 	bool bUseTermMerge = ( tCtx.m_bMergeSingles && pNode->m_dSpec.m_dZones.GetLength()==0 );
-	ISphWordlist::Args_t tWordlist ( bUseTermMerge, tCtx.m_iExpansionLimit, tCtx.m_bHasMorphology, tCtx.m_eHitless, tCtx.m_pIndexData );
+	ISphWordlist::Args_t tWordlist ( bUseTermMerge, tCtx.m_iExpansionLimit, tCtx.m_bHasMorphology, tCtx.m_eHitless, tCtx.m_pIndexData, tCtx.m_dKeywords );
 
 	if ( !sphIsWild(*sFull) || tCtx.m_iMinInfixLen==0 )
 	{
@@ -18745,6 +18745,7 @@ ExpansionContext_t::ExpansionContext_t()
 	, m_pPayloads ( NULL )
 	, m_eHitless ( SPH_HITLESS_NONE )
 	, m_pIndexData ( NULL )
+	, m_dKeywords ( NULL )
 {}
 
 
@@ -31766,12 +31767,13 @@ const BYTE * CWordlist::AcquireDict ( const CSphWordlistCheckpoint * pCheckpoint
 }
 
 
-ISphWordlist::Args_t::Args_t ( bool bPayload, int iExpansionLimit, bool bHasMorphology, ESphHitless eHitless, const void * pIndexData )
+ISphWordlist::Args_t::Args_t ( bool bPayload, int iExpansionLimit, bool bHasMorphology, ESphHitless eHitless, const void * pIndexData, CSphVector <CSphKeywordInfo> * dKeywords )
 	: m_bPayload ( bPayload )
 	, m_iExpansionLimit ( iExpansionLimit )
 	, m_bHasMorphology ( bHasMorphology )
 	, m_eHitless ( eHitless )
 	, m_pIndexData ( pIndexData )
+	, m_dKeywords ( dKeywords )
 {
 	m_sBuf.Reserve ( 2048 * SPH_MAX_WORD_LEN * 3 );
 	m_dExpanded.Reserve ( 2048 );

--- a/src/sphinx.h
+++ b/src/sphinx.h
@@ -3305,7 +3305,7 @@ public:
 	virtual bool				MultiQueryEx ( int iQueries, const CSphQuery * ppQueries, CSphQueryResult ** ppResults, ISphMatchSorter ** ppSorters, const CSphMultiQueryArgs & tArgs ) const = 0;
 	virtual bool				GetKeywords ( CSphVector <CSphKeywordInfo> & dKeywords, const char * szQuery, bool bGetStats, CSphString * pError ) const = 0;
 	virtual bool				FillKeywords ( CSphVector <CSphKeywordInfo> & dKeywords ) const = 0;
-	virtual bool				GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError ) { return true; }
+	virtual bool				GetExpansions ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError ) { return true; }
 
 public:
 	/// updates memory-cached attributes in real time

--- a/src/sphinx.h
+++ b/src/sphinx.h
@@ -3305,6 +3305,7 @@ public:
 	virtual bool				MultiQueryEx ( int iQueries, const CSphQuery * ppQueries, CSphQueryResult ** ppResults, ISphMatchSorter ** ppSorters, const CSphMultiQueryArgs & tArgs ) const = 0;
 	virtual bool				GetKeywords ( CSphVector <CSphKeywordInfo> & dKeywords, const char * szQuery, bool bGetStats, CSphString * pError ) const = 0;
 	virtual bool				FillKeywords ( CSphVector <CSphKeywordInfo> & dKeywords ) const = 0;
+	virtual bool				GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError ) { return true; }
 
 public:
 	/// updates memory-cached attributes in real time

--- a/src/sphinxint.h
+++ b/src/sphinxint.h
@@ -1936,7 +1936,7 @@ inline bool sphIsExpandedPayload ( int iDocs, int iHits )
 }
 
 void sphAddKeyword ( CSphVector <CSphKeywordInfo> * pKeywords, const char * sWord, int iDocs, int iHits );
-
+bool sphCheckParsedQuery ( bool & bParsed, XQQuery_t & tParsed, CSphString * pError );
 
 template<typename T>
 struct ExpandedOrderDesc_T

--- a/src/sphinxint.h
+++ b/src/sphinxint.h
@@ -1872,7 +1872,7 @@ public:
 		int							m_iTotalDocs;
 		int							m_iTotalHits;
 		const void *				m_pIndexData;
-		CSphVector <CSphKeywordInfo> * m_dKeywords;
+		CSphVector <CSphKeywordInfo> * m_pKeywords;
 
 		Args_t ( bool bPayload, int iExpansionLimit, bool bHasMorphology, ESphHitless eHitless, const void * pIndexData, CSphVector <CSphKeywordInfo> * dKeywords );
 		~Args_t ();
@@ -1918,7 +1918,7 @@ struct ExpansionContext_t
 	CSphScopedPayload * m_pPayloads;
 	ESphHitless m_eHitless;
 	const void * m_pIndexData;
-	CSphVector <CSphKeywordInfo> * m_dKeywords;
+	CSphVector <CSphKeywordInfo> * m_pKeywords;
 
 	ExpansionContext_t ();
 };
@@ -1934,6 +1934,8 @@ inline bool sphIsExpandedPayload ( int iDocs, int iHits )
 {
 	return ( iHits<=256 || iDocs<32 ); // magic threshold; mb make this configurable?
 }
+
+void sphAddKeyword ( CSphVector <CSphKeywordInfo> * pKeywords, const char * sWord, int iDocs, int iHits );
 
 
 template<typename T>

--- a/src/sphinxint.h
+++ b/src/sphinxint.h
@@ -1872,8 +1872,9 @@ public:
 		int							m_iTotalDocs;
 		int							m_iTotalHits;
 		const void *				m_pIndexData;
+		CSphVector <CSphKeywordInfo> * m_dKeywords;
 
-		Args_t ( bool bPayload, int iExpansionLimit, bool bHasMorphology, ESphHitless eHitless, const void * pIndexData );
+		Args_t ( bool bPayload, int iExpansionLimit, bool bHasMorphology, ESphHitless eHitless, const void * pIndexData, CSphVector <CSphKeywordInfo> * dKeywords );
 		~Args_t ();
 		void AddExpanded ( const BYTE * sWord, int iLen, int iDocs, int iHits );
 		const char * GetWordExpanded ( int iIndex ) const;
@@ -1917,6 +1918,7 @@ struct ExpansionContext_t
 	CSphScopedPayload * m_pPayloads;
 	ESphHitless m_eHitless;
 	const void * m_pIndexData;
+	CSphVector <CSphKeywordInfo> * m_dKeywords;
 
 	ExpansionContext_t ();
 };

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -1220,7 +1220,7 @@ public:
 	virtual bool				GetKeywords ( CSphVector <CSphKeywordInfo> & dKeywords, const char * szQuery, bool bGetStats, CSphString * pError ) const;
 	virtual bool				FillKeywords ( CSphVector <CSphKeywordInfo> & dKeywords ) const;
 	void						AddKeywordStats ( BYTE * sWord, const BYTE * sTokenized, CSphDict * pDict, bool bGetStats, int iQpos, RtQword_t * pQueryWord, CSphVector <CSphKeywordInfo> & dKeywords, const SphChunkGuard_t & tGuard ) const;
-	virtual bool				GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError );
+	virtual bool				GetExpansions ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError );
 
 	void						CopyDocinfo ( CSphMatch & tMatch, const DWORD * pFound ) const;
 	const CSphRowitem *			FindDocinfo ( const RtSegment_t * pSeg, SphDocID_t uDocID ) const;
@@ -7547,7 +7547,7 @@ bool RtIndex_t::FillKeywords ( CSphVector<CSphKeywordInfo> & dKeywords ) const
 XQNode_t * VLNExpandPrefix ( const CSphIndex * pIndex, XQNode_t * pNode, CSphQueryResultMeta * pResult,
 							 CSphScopedPayload * pPayloads, CSphVector <CSphKeywordInfo> * pKeywords );
 
-bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError )
+bool RtIndex_t::GetExpansions ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError )
 {
 	// REFACTOR:
 
@@ -7583,12 +7583,6 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 	bool bRes = sphParseExtendedQuery ( tParsed, pQuery->m_sQuery.cstr(), pQuery, pTokenizer.Ptr(), &m_tSchema, pDict, m_tSettings );
 	if ( sphCheckParsedQuery ( bRes, tParsed, pError ) )
 	{
-		// REFACTOR:
-
-		// this should be after keyword expansion
-		if ( m_tSettings.m_uAotFilterMask )
-			TransformAotFilter ( tParsed.m_pRoot, pDict->GetWordforms(), m_tSettings );
-
 		CSphQueryResultMeta tResults;
 
 		ARRAY_FOREACH ( iChunk, tGuard.m_dDiskChunks )
@@ -7616,8 +7610,6 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 			tExpCtx.m_pKeywords = &dKeywords;
 
 			tParsed.m_pRoot = sphExpandXQNode ( tParsed.m_pRoot, tExpCtx );
-
-			// REFACTOR:
 		}
 	}
 

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -7580,22 +7580,8 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 
 	XQQuery_t tParsed;
 	// FIXME!!! provide segments list instead index to tTermSetup.m_pIndex
-	bool bParsed = sphParseExtendedQuery ( tParsed, pQuery->m_sQuery.cstr(), pQuery, pTokenizer.Ptr(), &m_tSchema, pDict, m_tSettings );
-
-	bool bRes = true;
-	if ( !bParsed )
-	{
-		*pError = tParsed.m_sParseError;
-		bRes = false;
-	}
-	// TODO: send as warning
-	if ( bRes && !tParsed.m_sParseWarning.IsEmpty() )
-	{
-		*pError = tParsed.m_sParseWarning;
-		bRes = false;
-	}
-
-	if ( bRes )
+	bool bRes = sphParseExtendedQuery ( tParsed, pQuery->m_sQuery.cstr(), pQuery, pTokenizer.Ptr(), &m_tSchema, pDict, m_tSettings );
+	if ( sphCheckParsedQuery ( bRes, tParsed, pError ) )
 	{
 		// REFACTOR:
 

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -6037,13 +6037,23 @@ struct RtExpandedTraits_fn
 	const BYTE * m_sBase;
 };
 
+void sphAddKeyword ( CSphVector <CSphKeywordInfo> * pKeywords, const char * sWord, int iDocs, int iHits )
+{
+	CSphKeywordInfo & tInfo = pKeywords->Add();
+	// maybe 1 byte < 0x20 - magic prefix
+	if ( BYTE(*sWord) < 0x20 )
+		sWord++;
+	tInfo.m_sNormalized = sWord;
+	tInfo.m_iDocs = iDocs;
+	tInfo.m_iHits = iHits;
+}
 
 struct DictEntryRtPayload_t
 {
-	DictEntryRtPayload_t ( bool bPayload, int iSegments, CSphVector <CSphKeywordInfo> * dKeywords )
+	DictEntryRtPayload_t ( bool bPayload, int iSegments, CSphVector <CSphKeywordInfo> * pKeywords )
 	{
 		m_bPayload = bPayload;
-		m_dKeywords = dKeywords;
+		m_pKeywords = pKeywords;
 
 		if ( bPayload )
 		{
@@ -6062,18 +6072,10 @@ struct DictEntryRtPayload_t
 
 	void Add ( const RtWord_t * pWord, int iSegment )
 	{
-		if ( m_dKeywords )
+		if ( m_pKeywords )
 		{
-			CSphKeywordInfo & tInfo = m_dKeywords->Add();
 			// 1 byte - length
-			// maybe 1 byte < 0x20 - magic prefix
-			const char * sWord = (const char *)pWord->m_sWord + 1;
-			if ( BYTE(*sWord) < 0x20 )
-				sWord++;
-			tInfo.m_sNormalized = sWord;
-			tInfo.m_iDocs = pWord->m_uDocs;
-			tInfo.m_iHits = pWord->m_uHits;
-
+			sphAddKeyword ( m_pKeywords, (const char *)pWord->m_sWord + 1, pWord->m_uDocs, pWord->m_uHits );
 			return;
 		}
 
@@ -6204,14 +6206,14 @@ struct DictEntryRtPayload_t
 	CSphVector<RtExpandedPayload_t>	m_dWordPayload;
 	CSphVector<BYTE>				m_dWordBuf;
 	CSphVector<Slice_t>				m_dSeg;
-	CSphVector <CSphKeywordInfo> *  m_dKeywords;
+	CSphVector <CSphKeywordInfo> *  m_pKeywords;
 };
 
 
 void RtIndex_t::GetPrefixedWords ( const char * sSubstring, int iSubLen, const char * sWildcard, Args_t & tArgs ) const
 {
 	const CSphFixedVector<RtSegment_t*> & dSegments = *((CSphFixedVector<RtSegment_t*> *)tArgs.m_pIndexData);
-	DictEntryRtPayload_t tDict2Payload ( tArgs.m_bPayload, dSegments.GetLength(), tArgs.m_dKeywords );
+	DictEntryRtPayload_t tDict2Payload ( tArgs.m_bPayload, dSegments.GetLength(), tArgs.m_pKeywords );
 	const int iSkipMagic = ( BYTE(*sSubstring)<0x20 ); // whether to skip heading magic chars in the prefix, like NONSTEMMED maker
 	ARRAY_FOREACH ( iSeg, dSegments )
 	{
@@ -6320,7 +6322,7 @@ void RtIndex_t::GetInfixedWords ( const char * sSubstring, int iSubLen, const ch
 	const int iSkipMagic = ( tArgs.m_bHasMorphology ? 1 : 0 ); // whether to skip heading magic chars in the prefix, like NONSTEMMED maker
 	const CSphFixedVector<RtSegment_t*> & dSegments = *((CSphFixedVector<RtSegment_t*> *)tArgs.m_pIndexData);
 
-	DictEntryRtPayload_t tDict2Payload ( tArgs.m_bPayload, dSegments.GetLength(), tArgs.m_dKeywords );
+	DictEntryRtPayload_t tDict2Payload ( tArgs.m_bPayload, dSegments.GetLength(), tArgs.m_pKeywords );
 	ARRAY_FOREACH ( iSeg, dSegments )
 	{
 		const RtSegment_t * pSeg = dSegments[iSeg];
@@ -7542,6 +7544,9 @@ bool RtIndex_t::FillKeywords ( CSphVector<CSphKeywordInfo> & dKeywords ) const
 	return bGot;
 }
 
+XQNode_t * VLNExpandPrefix ( const CSphIndex * pIndex, XQNode_t * pNode, CSphQueryResultMeta * pResult,
+							 CSphScopedPayload * pPayloads, CSphVector <CSphKeywordInfo> * pKeywords );
+
 bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError )
 {
 	// REFACTOR:
@@ -7598,6 +7603,11 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 		if ( m_tSettings.m_uAotFilterMask )
 			TransformAotFilter ( tParsed.m_pRoot, pDict->GetWordforms(), m_tSettings );
 
+		CSphQueryResultMeta tResults;
+
+		ARRAY_FOREACH ( iChunk, tGuard.m_dDiskChunks )
+			tParsed.m_pRoot = VLNExpandPrefix ( tGuard.m_dDiskChunks[iChunk], tParsed.m_pRoot, &tResults, NULL, &dKeywords );
+
 		// expanding prefix in word dictionary case
 		CSphScopedPayload tPayloads;
 		if ( m_bKeywordDict && ( m_tSettings.m_iMinPrefixLen>0 || m_tSettings.m_iMinInfixLen>0 ) )
@@ -7606,7 +7616,7 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 			tExpCtx.m_pWordlist = this;
 			tExpCtx.m_pBuf = NULL;
 
-			CSphQueryResultMeta tResults;
+			//CSphQueryResultMeta tResults;
 			tExpCtx.m_pResult = &tResults;
 
 			tExpCtx.m_iMinPrefixLen = m_tSettings.m_iMinPrefixLen;
@@ -7617,7 +7627,7 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 			tExpCtx.m_pPayloads = &tPayloads;
 			tExpCtx.m_pIndexData = &tGuard.m_dRamChunks;
 
-			tExpCtx.m_dKeywords = &dKeywords;
+			tExpCtx.m_pKeywords = &dKeywords;
 
 			tParsed.m_pRoot = sphExpandXQNode ( tParsed.m_pRoot, tExpCtx );
 

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -1220,6 +1220,7 @@ public:
 	virtual bool				GetKeywords ( CSphVector <CSphKeywordInfo> & dKeywords, const char * szQuery, bool bGetStats, CSphString * pError ) const;
 	virtual bool				FillKeywords ( CSphVector <CSphKeywordInfo> & dKeywords ) const;
 	void						AddKeywordStats ( BYTE * sWord, const BYTE * sTokenized, CSphDict * pDict, bool bGetStats, int iQpos, RtQword_t * pQueryWord, CSphVector <CSphKeywordInfo> & dKeywords, const SphChunkGuard_t & tGuard ) const;
+	virtual bool				GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError );
 
 	void						CopyDocinfo ( CSphMatch & tMatch, const DWORD * pFound ) const;
 	const CSphRowitem *			FindDocinfo ( const RtSegment_t * pSeg, SphDocID_t uDocID ) const;
@@ -7523,6 +7524,91 @@ bool RtIndex_t::FillKeywords ( CSphVector<CSphKeywordInfo> & dKeywords ) const
 	return bGot;
 }
 
+bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CSphQuery * pQuery, CSphString * pError )
+{
+	// REFACTOR:
+
+	// force ext2 mode for them
+	// FIXME! eliminate this const breakage
+	const_cast<CSphQuery*> ( pQuery )->m_eMode = SPH_MATCH_EXTENDED2;
+
+	SphChunkGuard_t tGuard;
+	GetReaderChunks ( tGuard );
+
+	// wrappers
+	// OPTIMIZE! make a lightweight clone here? and/or remove double clone?
+	CSphScopedPtr<ISphTokenizer> pTokenizer ( m_pTokenizer->Clone ( SPH_CLONE_QUERY ) );
+	sphSetupQueryTokenizer ( pTokenizer.Ptr() );
+
+	CSphScopedPtr<CSphDict> tDictCloned ( NULL );
+	CSphDict * pDict = m_pDict;
+	if ( pDict->HasState() )
+	{
+		tDictCloned = pDict = pDict->Clone();
+	}
+
+	CSphScopedPtr<CSphDict> tDictStar ( NULL );
+	pDict = SetupStarDict ( tDictStar, pDict, pTokenizer.Ptr() );
+
+	CSphScopedPtr<CSphDict> tDictExact ( NULL );
+	pDict = SetupExactDict ( tDictExact, pDict, pTokenizer.Ptr(), true );
+
+	// REFACTOR:
+
+	XQQuery_t tParsed;
+	// FIXME!!! provide segments list instead index to tTermSetup.m_pIndex
+	bool bParsed = sphParseExtendedQuery ( tParsed, pQuery->m_sQuery.cstr(), pQuery, pTokenizer.Ptr(), &m_tSchema, pDict, m_tSettings );
+
+	bool bRes = true;
+	if ( !bParsed )
+	{
+		*pError = tParsed.m_sParseError;
+		bRes = false;
+	}
+	// TODO: send as warning
+	if ( bRes && !tParsed.m_sParseWarning.IsEmpty() )
+	{
+		*pError = tParsed.m_sParseWarning;
+		bRes = false;
+	}
+
+	if ( bRes )
+	{
+		// REFACTOR:
+
+		// this should be after keyword expansion
+		if ( m_tSettings.m_uAotFilterMask )
+			TransformAotFilter ( tParsed.m_pRoot, pDict->GetWordforms(), m_tSettings );
+
+		// expanding prefix in word dictionary case
+		CSphScopedPayload tPayloads;
+		if ( m_bKeywordDict && ( m_tSettings.m_iMinPrefixLen>0 || m_tSettings.m_iMinInfixLen>0 ) )
+		{
+			ExpansionContext_t tExpCtx;
+			tExpCtx.m_pWordlist = this;
+			tExpCtx.m_pBuf = NULL;
+
+			CSphQueryResultMeta tResults;
+			tExpCtx.m_pResult = &tResults;
+
+			tExpCtx.m_iMinPrefixLen = m_tSettings.m_iMinPrefixLen;
+			tExpCtx.m_iMinInfixLen = m_tSettings.m_iMinInfixLen;
+			tExpCtx.m_iExpansionLimit = m_iExpansionLimit;
+			tExpCtx.m_bHasMorphology = m_pDict->HasMorphology();
+			tExpCtx.m_bMergeSingles = true;
+			tExpCtx.m_pPayloads = &tPayloads;
+			tExpCtx.m_pIndexData = &tGuard.m_dRamChunks;
+
+			tParsed.m_pRoot = sphExpandXQNode ( tParsed.m_pRoot, tExpCtx );
+
+			// REFACTOR:
+
+			// :TODO!!!:
+		}
+	}
+
+	return bRes;
+}
 
 static const RtSegment_t * UpdateFindSegment ( const SphChunkGuard_t & tGuard, const CSphRowitem ** ppRow, SphDocID_t uDocID )
 {

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -7632,8 +7632,6 @@ bool RtIndex_t::GetSuggests ( CSphVector <CSphKeywordInfo> & dKeywords, const CS
 			tParsed.m_pRoot = sphExpandXQNode ( tParsed.m_pRoot, tExpCtx );
 
 			// REFACTOR:
-
-			// :TODO!!!:
 		}
 	}
 


### PR DESCRIPTION
Hello Upstream!

I would like to propose a new feature to Sphinx (because Sphinx is awesome): 
CALL SUGGESTS()
This feature concerns keyword autocomplete suggestions.

The traditional way is to build frequency dictionary of keywords using indexer --buildstops, but it is not possible now with RT indexes, see http://sphinxsearch.com/bugs/view.php?id=2011 . And after it you need to create another index like in http://sphinxsearch.com/blog/2013/05/21/simple-autocomplete-and-correction-suggestion/ .

With this pull request I propose a builtin way to request keyword suggestions, which I implemented now for local and rt indexes. It works like that:

```
mysql> CALL SUGGESTS('en*', 'projects');
+-----------+------+------+
| suggest   | docs | hits |
+-----------+------+------+
| en        | 86   | 90   |
| enru      | 3    | 3    |
| encrypt   | 1    | 2    |
| encrypted | 1    | 2    |
| end       | 1    | 2    |
| ene       | 1    | 1    |
| enes      | 1    | 1    |
+-----------+------+------+
7 rows in set (0.00 sec)
```

It works around sphExpandXQNode() call like SELECT does for expanding wildcards, but not doing full search, expanding only.

Synopsis:
CALL SUGGESTS(query, index_name[, limit]);

I think I got rather feature complete solution, but I am open to comments to improve the patch.
