### PR TITLE
Fix compilation with musl c library

### DIFF
--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -57,6 +57,9 @@
 #endif
 #endif
 
+// PAGE_SIZE may be in <limits.h>
+#undef PAGE_SIZE
+
 #if USE_LIBICONV
 #include "iconv.h"
 #endif


### PR DESCRIPTION
Currently compilation on linux systems using the musl c library (http://musl-libc.org) fails with the error 'expected unqualified-id before numeric constant' in sphinx.cpp. See http://bluedragon-tinderbox.freeharbor.net/app-misc/sphinx-2.1.9/temp/build.log for a complete failing build log.
