### PR TITLE
fixed php API to the php 5, new style constructor #20

### DIFF
--- a/api/sphinxapi.php
+++ b/api/sphinxapi.php
@@ -461,7 +461,7 @@ class SphinxClient
 	/////////////////////////////////////////////////////////////////////////////
 
 	/// create a new client object and fill defaults
-	function SphinxClient ()
+	function __construct ()
 	{
 		// per-client-object settings
 		$this->_host		= "localhost";


### PR DESCRIPTION
In PHP 7.0, the old style constructor is deprecated.
