### PR TITLE
missed part of #2459 for all indexes

### DIFF
--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -1946,6 +1946,8 @@ int main ( int argc, char ** argv )
 				tmRotated = sphMicroTimer();
 			if ( bLastOk )
 				iIndexed++;
+			else
+				iFailed++;
 		}
 	} else
 	{


### PR DESCRIPTION
Fixes http://sphinxsearch.com/bugs/view.php?id=2459 for case `indexer --all` if bad index present.
