### PR TITLE
Add missing documentation for 64-bit signed integers used as doc attributes

### DIFF
--- a/doc/sphinx.html
+++ b/doc/sphinx.html
@@ -450,12 +450,12 @@ the data, and to be easily accessed by scripting languages. However, Sphinx
 does not depend on nor require any specific database to function.
 </p><p>
 Applications can access Sphinx search daemon (searchd) using any of
-the three different access methods: a) via Sphinx own implementation of MySQL 
+the three different access methods: a) via Sphinx own implementation of MySQL
 network protocol (using a small SQL subset called SphinxQL, this is recommended
 way), b) via native search API (SphinxAPI) or c) via MySQL server with a
 pluggable storage engine (SphinxSE).
 </p><p>
-Official native SphinxAPI implementations for PHP, Perl, Python, Ruby and Java 
+Official native SphinxAPI implementations for PHP, Perl, Python, Ruby and Java
 are included within the distribution package. API is very lightweight
 so porting it to a new language is known to take a few hours or days.
 Third party API ports and plugins exist for Perl, C#, Haskell,
@@ -628,8 +628,8 @@ during last years, the obvious decision is to continue developing Sphinx
 </dl></div>
 <div class="sect1" title="2.1.&nbsp;Supported systems"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a name="supported-system"></a>2.1.&nbsp;Supported systems</h2></div></div></div>
 <p>
-Sphinx can be compiled either from source or installed using prebuilt 
-packages. Most modern UNIX systems with a C++ compiler should be able 
+Sphinx can be compiled either from source or installed using prebuilt
+packages. Most modern UNIX systems with a C++ compiler should be able
 to compile and run Sphinx without any modifications.
 </p><p>
 Currently known systems Sphinx has been successfully running on are:
@@ -731,7 +731,7 @@ do not seem to help you, please don't hesitate to contact me.
 </ol></div>
 <p>Sphinx <code class="filename">searchd</code> daemon can be started/stopped using service command:</p><p><strong class="userinput"><code>$ sudo service sphinxsearch start</code></strong></p></div>
 <div class="sect1" title="2.4.&nbsp;Installing Sphinx packages on RedHat and CentOS"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a name="installing-redhat"></a>2.4.&nbsp;Installing Sphinx packages on RedHat and CentOS</h2></div></div></div>
-<p>Currently we distribute Sphinx RPMS and SRPMS on our website for both 5.x and 6.x 
+<p>Currently we distribute Sphinx RPMS and SRPMS on our website for both 5.x and 6.x
 versions of Red Hat Enterprise Linux, but they can be installed on CentOS as well.</p><div class="orderedlist"><ol class="orderedlist" type="1"><li class="listitem"><p>Before installation make sure you have these packages installed:</p><p><strong class="userinput"><code>$ yum install postgresql-libs unixODBC</code></strong></p></li>
 <li class="listitem"><p>Download RedHat RPM from Sphinx website and install it:</p><p><strong class="userinput"><code>$ rpm -Uhv sphinx-2.2.1-1.rhel6.x86_64.rpm</code></strong></p></li>
 <li class="listitem"><p>After preparing configuration file (see <a class="link" href="#quick-tour" title="2.7.&nbsp;Quick Sphinx usage tour">Quick tour</a>), you can start searchd daemon:</p><p><strong class="userinput"><code>$ service searchd start</code></strong></p></li>
@@ -806,7 +806,7 @@ possible that someone may use it. And now we're urging you: don't use it.
 The default value is 'inline' and it's a new standard. 'plain' hit_format
 is obsolete and will be removed in the near future.</p></li>
 <li class="listitem"><p>docinfo=inline is deprecated. You can now use
-<a class="link" href="#conf-ondisk-attrs" title="12.2.68.&nbsp;ondisk_attrs">ondisk_attrs</a> or 
+<a class="link" href="#conf-ondisk-attrs" title="12.2.68.&nbsp;ondisk_attrs">ondisk_attrs</a> or
 <a class="link" href="#conf-ondisk-attrs-default" title="12.4.46.&nbsp;ondisk_attrs_default">ondisk_attrs_default</a> instead.</p></li>
 <li class="listitem"><p>workers=threads is a new default for all OS now.
 We're gonna get rid of other modes in future.</p></li>
@@ -1039,6 +1039,7 @@ Attributes are named. Attribute names are case insensitive.
 Attributes are <span class="emphasis"><em>not</em></span> full-text indexed; they are stored in the index as is.
 Currently supported attribute types are:
 </p><div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem"><p>unsigned integers (1-bit to 32-bit wide);</p></li>
+<li class="listitem"><p>signed big integers (64-bit wide);</p></li>
 <li class="listitem"><p>UNIX timestamps;</p></li>
 <li class="listitem"><p>floating point values (32-bit, IEEE 754 single precision);</p></li>
 <li class="listitem"><p><a class="link" href="#conf-sql-attr-string" title="12.1.23.&nbsp;sql_attr_string">strings</a> (since 1.10-beta);</p></li>
@@ -2499,7 +2500,7 @@ atc = log(1+sum(pair_tc))
 Note that this final dampening logarithm is exactly the reason you should use
 OPTION idf=plain, because without it, the expression inside the log() could be negative.
 </p><p>
-Having closer keyword occurrences actually contributes <span class="emphasis"><em>much</em></span> more 
+Having closer keyword occurrences actually contributes <span class="emphasis"><em>much</em></span> more
 to ATC than having more frequent keywords. Indeed, when the keywords are right next to
 each other, distance=1 and k=1; when there just one word in between them, distance=2 and
 k=0.297, with two words between, distance=3 and k=0.146, and so on. At the same time
@@ -2846,10 +2847,10 @@ LENGTH(json_attr.some_array) returns number of elements in array.
 <dd><p>Returns sort key value of the worst found element in the current top-N matches if sort key is float and 0 otherwise.</p></dd><dt><span class="term"><a name="expr-func-min-top-weight"></a>MIN_TOP_WEIGHT()</span></dt>
 <dd><p>Returns weight of the worst found element in the current top-N matches.</p></dd><dt><span class="term"><a name="expr-func-packedfactors"></a>PACKEDFACTORS()</span></dt>
 <dd><p>
-PACKEDFACTORS(), introduced in version 2.1.1-beta, can be used in queries, 
+PACKEDFACTORS(), introduced in version 2.1.1-beta, can be used in queries,
 either to just see all the weighting factors calculated when doing the matching, or to
 provide a binary attribute that can be used to write a custom ranking UDF.
-This function works only if expression ranker is specified and the query 
+This function works only if expression ranker is specified and the query
 is not a full scan, otherwise it will return an error. Starting with 2.2.2-beta
 PACKEDFACTORS() can take an optional argument that disables ATC ranking factor calculation:
 </p><pre class="programlisting">
@@ -2932,7 +2933,7 @@ WHERE match('hello')
 ORDER BY r DESC
 OPTION ranker=expr('1');
 </pre><p>
-Where CUSTOM_RANK() is a function implemented in an UDF. It should declare a 
+Where CUSTOM_RANK() is a function implemented in an UDF. It should declare a
 SPH_UDF_FACTORS structure (defined in <code class="filename">sphinxudf.h</code>), initialize this structure,
 unpack the factors into it before usage, and deinitialize it afterwards, as follows:
 </p><pre class="programlisting">
@@ -3712,7 +3713,7 @@ is able to import standard C header, and emit standard dynamic libraries with
 properly exported functions. Of course, the path of least resistance is to write
 in either C++ or plain C. We provide an example UDF library written in plain C
 and implementing several functions (demonstrating a few different techniques)
-along with our source code, see 
+along with our source code, see
 <a class="ulink" href="https://github.com/sphinxsearch/sphinx/blob/master/src/udfexample.c" target="_top">src/udfexample.c</a>.
 That example includes
 <a class="ulink" href="https://github.com/sphinxsearch/sphinx/blob/master/src/sphinxudf.h" target="_top">src/sphinxudf.h</a>
@@ -4610,8 +4611,8 @@ is useful when you want to check your index before actually using it.
 <code class="filename">wordbreaker</code> is one of the helper tools within
 the Sphinx package, introduced in version 2.1.1-beta. It is used to
 split compound words, as usual in URLs, into its component words.
-For example, this tool can split "lordoftherings" into its four 
-component words, or "http://manofsteel.warnerbros.com" into "man 
+For example, this tool can split "lordoftherings" into its four
+component words, or "http://manofsteel.warnerbros.com" into "man
 of steel warner bros". This helps searching, without requiring
 prefixes or infixes: searching for "sphinx" wouldn't match "sphinxsearch"
 but if you break the compound word and index the separate components,
@@ -4627,15 +4628,15 @@ the splitting functionality.
 </p><p>Wordbreaker
 Wordbreaker needs a dictionary to recognize individual substrings within a string. To
 differentiate between different guesses, it uses the relative frequency of each
-word in the dictionary: higher frequency means higher split probability. You can 
+word in the dictionary: higher frequency means higher split probability. You can
 generate such a file using the <code class="filename">indexer</code> tool, as in
 </p><pre class="programlisting">
-indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.conf   
+indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.conf
 </pre><p>
 which will write the 100,000 most frequent words, along with their counts, from
 myindex into dict.txt. The output file is a text file, so you can edit it by hand,
 if need be, to add or remove words.
-</p><p>See 
+</p><p>See
 <a class="ulink" href="http://sphinxsearch.com/blog/2013/01/29/a-new-tool-in-the-trunk-wordbreaker/" target="_top">
 http://sphinxsearch.com/blog/2013/01/29/a-new-tool-in-the-trunk-wordbreaker/</a>
 for more on this tool.
@@ -4892,7 +4893,7 @@ lets you control a number of per-query options. The syntax is:
 OPTION &lt;optionname&gt;=&lt;value&gt; [ , ... ]
 </pre><p>
 Supported options and respectively allowed values are:
-</p><div class="itemizedlist"><ul class="itemizedlist" type="circle"><li class="listitem"><p>'agent_query_timeout' - integer (max time in milliseconds to wait for remote queries to complete, 
+</p><div class="itemizedlist"><ul class="itemizedlist" type="circle"><li class="listitem"><p>'agent_query_timeout' - integer (max time in milliseconds to wait for remote queries to complete,
 see <a class="link" href="#conf-agent-query-timeout" title="12.2.35.&nbsp;agent_query_timeout">agent_query_timeout</a> under Index configuration options for details)</p></li>
 <li class="listitem"><p>'boolean_simplify' - 0 or 1, enables simplifying the query to speed it up</p></li>
 <li class="listitem"><p>'comment' - string, user comment that gets copied to a query log file</p></li>
@@ -5088,7 +5089,7 @@ automatically execute this statement.
 SHOW META [ LIKE pattern ]
 </pre><p><span class="bold"><strong>SHOW META</strong></span> shows additional meta-information about the latest
 query such as query time and keyword statistics. IO and CPU counters will only be available if searchd was started with --iostats and --cpustats switches respectively.
-Additional predicted_time, dist_predicted_time, [{local|dist}]_fetched_[{docs|hits|skips}] counters will only be available if searchd was configured with  
+Additional predicted_time, dist_predicted_time, [{local|dist}]_fetched_[{docs|hits|skips}] counters will only be available if searchd was configured with
 <a class="link" href="#conf-predicted-time-costs" title="12.4.44.&nbsp;predicted_time_costs">predicted time costs</a> and query  had  predicted_time in OPTION clause.
 </p><pre class="programlisting">
 mysql&gt; SELECT * FROM test1 WHERE MATCH('test|one|two');
@@ -5770,7 +5771,7 @@ added in 2.2.2-beta.
 Implementation details. As of 2.2.1-beta, the querying of an index is
 impossible (because of a write lock) while adding a column. This may change
 in the future. The newly created attribute values are set to 0. ALTER will
-not work for distributed indexes and indexes without any attributes. 
+not work for distributed indexes and indexes without any attributes.
 DROP COLUMN will fail if an index has only one attribute.
 </p><pre class="programlisting">
 ALTER RTINDEX index RECONFIGURE
@@ -9936,7 +9937,7 @@ control character mapping.
 # default are English and Russian letters
 charset_table = 0..9, A..Z-&gt;a..z, _, a..z, \
     U+410..U+42F-&gt;U+430..U+44F, U+430..U+44F, U+401-&gt;U+451, U+451
-	
+
 # english charset defined with alias
 charset_table = 0..9, english, _
 </pre></div>
@@ -12168,15 +12169,15 @@ The last defined in distributed (network) indexes, or also may be overrided per-
 </p></div>
 <div class="sect2" title="12.4.50.&nbsp;agent_retry_count"><div class="titlepage"><div><div><h3 class="title"><a name="conf-agent-retry-count"></a>12.4.50.&nbsp;agent_retry_count</h3></div></div></div>
 <p>
-Integer, specifies how many times sphinx will try to connect and query remote agents in distributed index before reporting 
-fatal query error. Default is 0 (i.e. no retries). This value may be also specified on per-query basis using 
+Integer, specifies how many times sphinx will try to connect and query remote agents in distributed index before reporting
+fatal query error. Default is 0 (i.e. no retries). This value may be also specified on per-query basis using
 'OPTION retry_count=XXX' clause. If per-query option exists, it will override the one specified in config.
 </p></div>
 <div class="sect2" title="12.4.51.&nbsp;agent_retry_delay"><div class="titlepage"><div><div><h3 class="title"><a name="conf-agent-retry-delay"></a>12.4.51.&nbsp;agent_retry_delay</h3></div></div></div>
 <p>
 Integer, in milliseconds. Specifies the delay sphinx rest before retrying to query a remote agent in case it fails.
-The value has sense only if non-zero <a class="link" href="#conf-agent-retry-count" title="12.4.50.&nbsp;agent_retry_count">agent_retry_count</a> 
-or non-zero per-query OPTION retry_count specified. Default is 500. This value may be also specified 
+The value has sense only if non-zero <a class="link" href="#conf-agent-retry-count" title="12.4.50.&nbsp;agent_retry_count">agent_retry_count</a>
+or non-zero per-query OPTION retry_count specified. Default is 500. This value may be also specified
 on per-query basis using 'OPTION retry_delay=XXX' clause. If per-query option exists, it will override the one specified in config.
 </p></div>
 <div class="sect2" title="12.4.52.&nbsp;qcache_max_bytes"><div class="titlepage"><div><div><h3 class="title"><a name="conf-qcache-max-bytes"></a>12.4.52.&nbsp;qcache_max_bytes</h3></div></div></div>

--- a/doc/sphinx.txt
+++ b/doc/sphinx.txt
@@ -1287,10 +1287,10 @@ Example application code (in PHP):
 
    | // only search posts by author whose ID is 123
    | $cl->SetFilter ( "author_id", array ( 123 ) );
-   | 
+   |
    | // only search posts in sub-forums 1, 3 and 7
    | $cl->SetFilter ( "forum_id", array ( 1,3,7 ) );
-   | 
+   |
    | // sort found posts by posting date in descending order
    | $cl->SetSortMode ( SPH_SORT_ATTR_DESC, "post_date" );
 
@@ -1299,6 +1299,8 @@ not full-text indexed; they are stored in the index as is. Currently
 supported attribute types are:
 
    * unsigned integers (1-bit to 32-bit wide);
+
+   * signed big integers (64-bit wide);
 
    * UNIX timestamps;
 
@@ -1530,7 +1532,7 @@ fetch another chunk of documents. Here's an example.
 Example 3.1. Ranged query usage example
 
    | # in sphinx.conf
-   | 
+   |
    | sql_query_range = SELECT MIN(id),MAX(id) FROM documents
    | sql_range_step = 1000
    | sql_query = SELECT * FROM documents WHERE id>=$start AND id<=$end
@@ -1574,14 +1576,14 @@ Example 3.2. xmlpipe2 document stream
 
    | <?xml version="1.0" encoding="utf-8"?>
    | <sphinx:docset>
-   | 
+   |
    | <sphinx:schema>
    | <sphinx:field name="subject"/>
    | <sphinx:field name="content"/>
    | <sphinx:attr name="published" type="timestamp"/>
    | <sphinx:attr name="author_id" type="int" bits="16" default="1"/>
    | </sphinx:schema>
-   | 
+   |
    | <sphinx:document id="1234">
    | <content>this is the main content <![CDATA[[and this <cdata> entry
    | must be handled properly by xml parser lib]]></content>
@@ -1590,21 +1592,21 @@ Example 3.2. xmlpipe2 document stream
    | in <b class="red">randomized</b> order</subject>
    | <misc>some undeclared element</misc>
    | </sphinx:document>
-   | 
+   |
    | <sphinx:document id="1235">
    | <subject>another subject</subject>
    | <content>here comes another document, and i am given to understand,
    | that in-document field order must not matter, sir</content>
    | <published>1012325467</published>
    | </sphinx:document>
-   | 
+   |
    | <!-- ... even more sphinx:document entries here ... -->
-   | 
+   |
    | <sphinx:killlist>
    | <id>1234</id>
    | <id>4567</id>
    | </sphinx:killlist>
-   | 
+   |
    | </sphinx:docset>
 
 Arbitrary fields and attributes are allowed. They also can occur in the
@@ -1766,7 +1768,7 @@ Example 3.3. Fully automated live updates
    |     counter_id INTEGER PRIMARY KEY NOT NULL,
    |     max_doc_id INTEGER NOT NULL
    | );
-   | 
+   |
    | # in sphinx.conf
    | source main
    | {
@@ -1776,21 +1778,21 @@ Example 3.3. Fully automated live updates
    |     sql_query = SELECT id, title, body FROM documents \
    |         WHERE id<=( SELECT max_doc_id FROM sph_counter WHERE counter_id=1 )
    | }
-   | 
+   |
    | source delta : main
    | {
    |     sql_query_pre = SET NAMES utf8
    |     sql_query = SELECT id, title, body FROM documents \
    |         WHERE id>( SELECT max_doc_id FROM sph_counter WHERE counter_id=1 )
    | }
-   | 
+   |
    | index main
    | {
    |     source = main
    |     path = /path/to/main
    |     # ... all the other settings
    | }
-   | 
+   |
    | # note how all other settings are copied from main,
    | # but source and path are overridden (they MUST be)
    | index delta : main
@@ -1892,15 +1894,15 @@ example session with the sample index above:
    | Welcome to the MySQL monitor.  Commands end with ; or \g.
    | Your MySQL connection id is 1
    | Server version: 1.10-dev (r2153)
-   | 
+   |
    | Type 'help;' or '\h' for help. Type '\c' to clear the buffer.
-   | 
+   |
    | mysql> INSERT INTO rt VALUES ( 1, 'first record', 'test one', 123 );
    | Query OK, 1 row affected (0.05 sec)
-   | 
+   |
    | mysql> INSERT INTO rt VALUES ( 2, 'second record', 'test two', 234 );
    | Query OK, 1 row affected (0.00 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt;
    | +------+--------+------+
    | | id   | weight | gid  |
@@ -1909,7 +1911,7 @@ example session with the sample index above:
    | |    2 |      1 |  234 |
    | +------+--------+------+
    | 2 rows in set (0.02 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt WHERE MATCH('test');
    | +------+--------+------+
    | | id   | weight | gid  |
@@ -1918,7 +1920,7 @@ example session with the sample index above:
    | |    2 |   1643 |  234 |
    | +------+--------+------+
    | 2 rows in set (0.01 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt WHERE MATCH('@title test');
    | Empty set (0.00 sec)
 
@@ -1930,7 +1932,7 @@ to implement updates.
 
    | mysql> INSERT INTO rt ( id, title ) VALUES ( 3, 'third row' ), ( 4, 'fourth entry' );
    | Query OK, 2 rows affected (0.01 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt;
    | +------+--------+------+
    | | id   | weight | gid  |
@@ -1941,10 +1943,10 @@ to implement updates.
    | |    4 |      1 |    0 |
    | +------+--------+------+
    | 4 rows in set (0.00 sec)
-   | 
+   |
    | mysql> DELETE FROM rt WHERE id=2;
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt WHERE MATCH('test');
    | +------+--------+------+
    | | id   | weight | gid  |
@@ -1952,13 +1954,13 @@ to implement updates.
    | |    1 |   1500 |  123 |
    | +------+--------+------+
    | 1 row in set (0.00 sec)
-   | 
+   |
    | mysql> INSERT INTO rt VALUES ( 1, 'first record on steroids', 'test one', 123 );
    | ERROR 1064 (42000): duplicate id '1'
-   | 
+   |
    | mysql> REPLACE INTO rt VALUES ( 1, 'first record on steroids', 'test one', 123 );
    | Query OK, 1 row affected (0.01 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt WHERE MATCH('steroids');
    | +------+--------+------+
    | | id   | weight | gid  |
@@ -2466,7 +2468,7 @@ an implicit list of all documents:
 
    | // correct query
    | aaa -(bbb -(ccc ddd))
-   | 
+   |
    | // queries that are non-computable
    | -aaa
    | aaa | -bbb
@@ -2639,7 +2641,7 @@ omitted and the ranker name is case insensitive. Example:
 
    | // SphinxAPI
    | $client->SetRankingMode ( SPH_RANK_SPH04 );
-   | 
+   |
    | // SphinxQL
    | mysql_query ( "SELECT ... OPTION ranker=sph04" );
 
@@ -2679,7 +2681,7 @@ document-level ranking factors.
 5.4.4. Quick summary of the ranking factors
 -------------------------------------------
 
-Table 5.1. 
+Table 5.1.
 
 +-------------------+----------+-------+----------------------------------------------------+
 | Name              | Level    | Type  | Summary                                            |
@@ -3357,7 +3359,7 @@ GEODIST()
    and a few examples are as follows:
 
       | GEODIST(lat1, lon1, lat2, lon2, { option=value, ... })
-      | 
+      |
       | GEODIST(40.7643929, -73.9997683, 40.7642578, -73.9994565, {in=degrees, out=feet})
       | GEODIST(51.50, -0.12, 29.98, 31.13, {in=deg, out=mi}}
 
@@ -3441,14 +3443,14 @@ PACKEDFACTORS()
       |     word0=(tf=1, idf=-0.062982),
       |     word1=(tf=1, idf=0.215338)
       | 1 row in set (0.00 sec)
-      | 
+      |
       | mysql> SELECT id, PACKEDFACTORS({json=1}) FROM test1
       |     -> WHERE MATCH('test one') OPTION ranker=expr('1') \G
       | *************************** 1. row ***************************
       |                      id: 1
       | packedfactors({json=1}):
       | {
-      | 
+      |
       |     "bm25": 569,
       |     "bm25a": 0.617197,
       |     "field_mask": 2,
@@ -3483,7 +3485,7 @@ PACKEDFACTORS()
       |             "idf": 0.215338
       |         }
       |     ]
-      | 
+      |
       | }
       | 1 row in set (0.01 sec)
 
@@ -3893,7 +3895,7 @@ per line in the actual log.)
 
    | /* Fri Jun 29 21:17:58.609 2007 2011 conn 2 real 0.004 wall 0.004 found 35254 */
    | SELECT * FROM lj WHERE MATCH('test') OPTION ranker=proximity;
-   | 
+   |
    | /* Fri Jun 29 21:20:34 2007.555 conn 3 real 0.024 wall 0.024 found 19886 */
    | SELECT * FROM lj WHERE MATCH('test') GROUP BY channel_id
    | OPTION ranker=proximity;
@@ -3941,9 +3943,9 @@ querying Sphinx using MySQL client:
    | Welcome to the MySQL monitor.  Commands end with ; or \g.
    | Your MySQL connection id is 1
    | Server version: 0.9.9-dev (r1734)
-   | 
+   |
    | Type 'help;' or '\h' for help. Type '\c' to clear the buffer.
-   | 
+   |
    | mysql> SELECT * FROM test1 WHERE MATCH('test')
    |     -> ORDER BY group_id ASC OPTION ranker=bm25;
    | +------+--------+----------+------------+
@@ -4054,7 +4056,7 @@ sorting modes:
    | require ( "sphinxapi.php" );
    | $cl = new SphinxClient ();
    | $cl->SetMatchMode ( SPH_MATCH_EXTENDED );
-   | 
+   |
    | $cl->SetSortMode ( SPH_SORT_RELEVANCE );
    | $cl->AddQuery ( "the", "lj" );
    | $cl->SetSortMode ( SPH_SORT_EXTENDED, "published desc" );
@@ -4343,7 +4345,7 @@ library file, and you must return SPH_UDF_VERSION (a value defined in
 sphinxudf.h) from it. Here's an example.
 
    | #include <sphinxudf.h>
-   | 
+   |
    | // our library will be called udfexample.so, thus, so it must define
    | // a version function named udfexample_ver()
    | int udfexample_ver()
@@ -4400,11 +4402,11 @@ deinitialization, respectively.
    |     // allocate and initialize a little bit of temporary storage
    |     init->func_data = malloc ( sizeof(int) );
    |     *(int*)init->func_data = 123;
-   | 
+   |
    |     // return a success code
    |     return 0;
    | }
-   | 
+   |
    | void testfunc_deinit ( SPH_UDF_INIT * init )
    | {
    |     // free up our temporary storage
@@ -4592,7 +4594,7 @@ And this is how you use it:
 
    | mysql> CREATE PLUGIN myrank TYPE 'ranker' SONAME 'myrank.dll';
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | mysql> SELECT id, weight() FROM test1 WHERE MATCH('test')
    |     -> OPTION ranker=myrank('');
    | +------+----------+
@@ -5239,7 +5241,7 @@ uses the relative frequency of each word in the dictionary: higher
 frequency means higher split probability. You can generate such a file
 using the indexer tool, as in
 
-   | indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.conf   
+   | indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.conf
 
 which will write the 100,000 most frequent words, along with their counts,
 from myindex into dict.txt. The output file is a text file, so you can edit
@@ -5745,7 +5747,7 @@ predicted_time in OPTION clause.
    | |    4 |   1480 |        2 | 1231721236 |
    | +------+--------+----------+------------+
    | 3 rows in set (0.01 sec)
-   | 
+   |
    | mysql> SHOW META;
    | +-----------------------+-------+
    | | Variable_name         | Value |
@@ -5805,10 +5807,10 @@ be returned along with the query itself:
    | mysql> SELECT * FROM test1 WHERE MATCH('@@title hello') \G
    | ERROR 1064 (42000): index test1: syntax error, unexpected TOK_FIELDLIMIT
    | near '@title hello'
-   | 
+   |
    | mysql> SELECT * FROM test1 WHERE MATCH('@title -hello') \G
    | ERROR 1064 (42000): index test1: query is non-computable (single NOT operator)
-   | 
+   |
    | mysql> SELECT * FROM test1 WHERE MATCH('"test doc"/3') \G
    | *************************** 1. row ***************************
    |         id: 4
@@ -5816,7 +5818,7 @@ be returned along with the query itself:
    |   group_id: 2
    | date_added: 1231721236
    | 1 row in set, 1 warning (0.00 sec)
-   | 
+   |
    | mysql> SHOW WARNINGS \G
    | *************************** 1. row ***************************
    |   Level: warning
@@ -5937,10 +5939,10 @@ Section 8.1, <<SELECT syntax>> for details).
    | |  107 | 1007 | 107,208     | 107  |
    | +------+------+-------------+------+
    | 8 rows in set (0.00 sec)
-   | 
+   |
    | mysql> delete from rt where match ('dumy') and mva1>206;
    | Query OK, 2 rows affected (0.00 sec)
-   | 
+   |
    | mysql> select * from rt;
    | +------+------+-------------+------+
    | | id   | gid  | mva1        | mva2 |
@@ -5953,10 +5955,10 @@ Section 8.1, <<SELECT syntax>> for details).
    | |  105 | 1005 | 105,206     | 105  |
    | +------+------+-------------+------+
    | 6 rows in set (0.00 sec)
-   | 
+   |
    | mysql> delete from rt where id in (100,104,105);
    | Query OK, 3 rows affected (0.01 sec)
-   | 
+   |
    | mysql> select * from rt;
    | +------+------+---------+------+
    | | id   | gid  | mva1    | mva2 |
@@ -5966,10 +5968,10 @@ Section 8.1, <<SELECT syntax>> for details).
    | |  103 | 1003 | 103,204 | 103  |
    | +------+------+---------+------+
    | 3 rows in set (0.00 sec)
-   | 
+   |
    | mysql> delete from rt where mva1 in (102,204);
    | Query OK, 2 rows affected (0.01 sec)
-   | 
+   |
    | mysql> select * from rt;
    | +------+------+---------+------+
    | | id   | gid  | mva1    | mva2 |
@@ -6017,7 +6019,7 @@ distibuted index. Example:
    | // in session 1
    | mysql> SET GLOBAL @myfilter=(2,3,5,7,11,13);
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | // later in session 2
    | mysql> SELECT * FROM test1 WHERE group_id IN @myfilter;
    | +------+--------+----------+------------+-----------------+------+
@@ -6084,7 +6086,7 @@ Examples:
 
    | mysql> SET autocommit=0;
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | mysql> SET GLOBAL query_log_format=sphinxql;
    | Query OK, 0 rows affected (0.00 sec)
 
@@ -6256,7 +6258,7 @@ queries that the server receives. Example:
 
    | mysql> CREATE FUNCTION avgmva RETURNS INT SONAME 'udfexample.dll';
    | Query OK, 0 rows affected (0.03 sec)
-   | 
+   |
    | mysql> SELECT *, AVGMVA(tag) AS q from test1;
    | +------+--------+---------+-----------+
    | | id   | weight | tag     | q         |
@@ -6373,7 +6375,7 @@ float values in JSON array. No strings, arrays and other types yet.
 
    | mysql> UPDATE myindex SET enabled=0 WHERE id=123;
    | Query OK, 1 rows affected (0.00 sec)
-   | 
+   |
    | mysql> UPDATE myindex
    |   SET bigattr=-100000000000,
    |     fattr=3465.23,
@@ -6440,10 +6442,10 @@ warnings regarding the keyword sets mismatch.
    | | date_added | timestamp |
    | +------------+-----------+
    | 4 rows in set (0.01 sec)
-   | 
+   |
    | mysql> alter table plain add column test integer;
    | Query OK, 0 rows affected (0.04 sec)
-   | 
+   |
    | mysql> desc plain;
    | +------------+-----------+
    | | Field      | Type      |
@@ -6455,10 +6457,10 @@ warnings regarding the keyword sets mismatch.
    | | test       | uint      |
    | +------------+-----------+
    | 5 rows in set (0.00 sec)
-   | 
+   |
    | mysql> alter table plain drop column group_id;
    | Query OK, 0 rows affected (0.01 sec)
-   | 
+   |
    | mysql> desc plain;
    | +------------+-----------+
    | | Field      | Type      |
@@ -6514,10 +6516,10 @@ indexes. The complete list is as follows.
    | | testattr  | uint    |
    | +-----------+---------+
    | 3 rows in set (0.00 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt;
    | Empty set (0.00 sec)
-   | 
+   |
    | mysql> SELECT * FROM disk WHERE MATCH('test');
    | +------+--------+----------+------------+
    | | id   | weight | group_id | date_added |
@@ -6528,10 +6530,10 @@ indexes. The complete list is as follows.
    | |    4 |   1304 |        1 | 1313643256 |
    | +------+--------+----------+------------+
    | 4 rows in set (0.00 sec)
-   | 
+   |
    | mysql> ATTACH INDEX disk TO RTINDEX rt;
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | mysql> DESC rt;
    | +------------+-----------+
    | | Field      | Type      |
@@ -6543,7 +6545,7 @@ indexes. The complete list is as follows.
    | | date_added | timestamp |
    | +------------+-----------+
    | 5 rows in set (0.00 sec)
-   | 
+   |
    | mysql> SELECT * FROM rt WHERE MATCH('test');
    | +------+--------+----------+------------+
    | | id   | weight | group_id | date_added |
@@ -6554,7 +6556,7 @@ indexes. The complete list is as follows.
    | |    4 |   1304 |        1 | 1313643256 |
    | +------+--------+----------+------------+
    | 4 rows in set (0.00 sec)
-   | 
+   |
    | mysql> SELECT * FROM disk WHERE MATCH('test');
    | ERROR 1064 (42000): no enabled local indexes to search
 
@@ -6616,7 +6618,7 @@ since the daemon startup).
 
    | mysql> UPDATE testindex SET channel_id=1107025 WHERE id=1;
    | Query OK, 1 row affected (0.04 sec)
-   | 
+   |
    | mysql> FLUSH ATTRIBUTES;
    | +------+
    | | tag  |
@@ -6787,7 +6789,7 @@ Here's a complete instrumentation example:
 
    | mysql> SET profiling=1;
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | mysql> SELECT id FROM lj WHERE MATCH('the test') LIMIT 1;
    | +--------+
    | | id     |
@@ -6795,7 +6797,7 @@ Here's a complete instrumentation example:
    | | 946418 |
    | +--------+
    | 1 row in set (0.05 sec)
-   | 
+   |
    | mysql> SHOW PROFILE;
    | +--------------+----------+----------+
    | | Status       | Duration | Switches |
@@ -6961,12 +6963,12 @@ Here's a complete instrumentation example:
 
    | mysql> SET profiling=1 \G
    | Query OK, 0 rows affected (0.00 sec)
-   | 
+   |
    | mysql> SELECT id FROM lj WHERE MATCH('the i') LIMIT 1 \G
    | *************************** 1. row ***************************
    | id: 39815
    | 1 row in set (1.53 sec)
-   | 
+   |
    | mysql> SHOW PLAN \G
    | *************************** 1. row ***************************
    | Variable: transformed_tree
@@ -7149,17 +7151,17 @@ mysqli interface in PHP and DBI/DBD libraries in Perl are known to work.
 Here's a PHP sample showing how to utilize mysqli interface with Sphinx.
 
    | <?php
-   | 
+   |
    | $link = mysqli_connect ( "127.0.0.1", "root", "", "", 9306 );
    | if ( mysqli_connect_errno() )
    |     die ( "connect failed: " . mysqli_connect_error() );
-   | 
+   |
    | $batch = "SELECT * FROM test1 ORDER BY group_id ASC;";
    | $batch .= "SELECT * FROM test1 ORDER BY group_id DESC";
-   | 
+   |
    | if ( !mysqli_multi_query ( $link, $batch ) )
    |     die ( "query failed" );
-   | 
+   |
    | do
    | {
    |     // fetch and print result set
@@ -7169,11 +7171,11 @@ Here's a PHP sample showing how to utilize mysqli interface with Sphinx.
    |             printf ( "id=%s\n", $row[0] );
    |         mysqli_free_result($result);
    |     }
-   | 
+   |
    |     // print divider
    |     if ( mysqli_more_results($link) )
    |         printf ( "------\n" );
-   | 
+   |
    | } while ( mysqli_next_result($link) );
 
 Its output with the sample test1 index included with Sphinx is as follows.
@@ -8039,12 +8041,12 @@ to change them at all. Here's an example:
 
    | $cl->SetSortMode ( SPH_SORT_RELEVANCE );
    | $cl->AddQuery ( "hello world", "documents" );
-   | 
+   |
    | $cl->SetSortMode ( SPH_SORT_ATTR_DESC, "price" );
    | $cl->AddQuery ( "ipod", "products" );
-   | 
+   |
    | $cl->AddQuery ( "harry potter", "books" );
-   | 
+   |
    | $results = $cl->RunQueries ();
 
 With the code above, 1st query will search for "hello world" in "documents"
@@ -8572,7 +8574,7 @@ Let's begin with an example create statement and search query:
    |     group_id    INTEGER,
    |     INDEX(query)
    | ) ENGINE=SPHINX CONNECTION="sphinx://localhost:9312/test";
-   | 
+   |
    | SELECT * FROM t1 WHERE query='test it;mode=any';
 
 First 3 columns of search table must have a types of INTEGER UNSINGED or
@@ -8647,7 +8649,7 @@ number of options can be specified. Available options are:
 
       | # only include groups 1, 5 and 19
       | ... WHERE query='test;filter=group_id,1,5,19;';
-      | 
+      |
       | # exclude groups 3 and 11
       | ... WHERE query='test;!filter=group_id,3,11;';
 
@@ -8656,7 +8658,7 @@ number of options can be specified. Available options are:
 
       | # include groups from 3 to 7, inclusive
       | ... WHERE query='test;range=group_id,3,7;';
-      | 
+      |
       | # exclude groups from 5 to 25
       | ... WHERE query='test;!range=group_id,5,25;';
 
@@ -8665,7 +8667,7 @@ number of options can be specified. Available options are:
 
       | # filter by a float size
       | ... WHERE query='test;floatrange=size,2,3;';
-      | 
+      |
       | # pick all results within 1000 meter from geoanchor
       | ... WHERE query='test;floatrange=@geodist,0,1000;';
 
@@ -8833,7 +8835,7 @@ engines. Here's an example with "documents" from example.sql:
    | | this is my test document number one | 2006-06-17 14:04:28 |
    | +-------------------------------------+---------------------+
    | 2 rows in set (0.00 sec)
-   | 
+   |
    | mysql> SHOW ENGINE SPHINX STATUS;
    | +--------+-------+---------------------------------------------+
    | | Type   | Name  | Status                                      |
@@ -8876,7 +8878,7 @@ Usage examples:
    |     'sphinx://192.168.1.1/' AS sphinx, true AS exact_phrase,
    |     '[b]' AS before_match, '[/b]' AS after_match)
    | FROM documents;
-   | 
+   |
    | SELECT title, sphinx_snippets(text, 'index', 'mysql php') AS text
    |     FROM sphinx, documents
    |     WHERE query='mysql php' AND sphinx.id=documents.id;
@@ -9465,7 +9467,7 @@ Example:
    | sql_joined_field = \
    |     tagstext from query; \
    |     SELECT docid, CONCAT('tag',tagid) FROM tags ORDER BY docid ASC
-   | 
+   |
    | sql_joined_field = bigint tag from ranged-query; \
    |     SELECT id, tag FROM tags WHERE id>=$start AND id<=$end ORDER BY id ASC; \
    |     SELECT MIN(id), MAX(id) FROM tags
@@ -10173,7 +10175,7 @@ some additional information yourself. Two typical approaches include:
       |     sql_query = SELECT id*10+1, ... FROM table1
       |     ...
       | }
-      | 
+      |
       | source src2
       | {
       |     sql_query = SELECT id*10+2, ... FROM table2
@@ -10188,7 +10190,7 @@ some additional information yourself. Two typical approaches include:
       |     sql_attr_uint = source_id
       |     ...
       | }
-      | 
+      |
       | source src2
       | {
       |     sql_query = SELECT id, 2 AS source_id FROM table2
@@ -10906,7 +10908,7 @@ Example:
    | # default are English and Russian letters
    | charset_table = 0..9, A..Z->a..z, _, a..z, \
    |     U+410..U+42F->U+430..U+44F, U+430..U+44F, U+401->U+451, U+451
-   | 	
+   |
    | # english charset defined with alias
    | charset_table = 0..9, english, _
 
@@ -11306,12 +11308,12 @@ Example:
    | # sharding an index over 3 servers
    | agent = box2:9312:chunk2
    | agent = box3:9312:chunk3
-   | 
+   |
    | # config on box2
    | # sharding an index over 3 servers
    | agent = box1:9312:chunk2
    | agent = box3:9312:chunk3
-   | 
+   |
    | # config on box3
    | # sharding an index over 3 servers
    | agent = box1:9312:chunk2
@@ -11367,10 +11369,10 @@ Example:
    | # in just 2 chunks but with 2 failover mirrors for each chunk
    | # box1, box2 carry chunk1 as local
    | # box3, box4 carry chunk2 as local
-   | 
+   |
    | # config on box1, box2
    | agent = box3:9312|box4:9312:chunk2
-   | 
+   |
    | # config on box3, box4
    | agent = box1:9312|box2:9312:chunk1
 
@@ -12118,7 +12120,7 @@ Example:
 
    | # index '13-inch' as '13inch'
    | regexp_filter = \b(\d+)\" => \1inch
-   | 
+   |
    | # index 'blue' or 'red' as 'color'
    | regexp_filter = (blue|red) => color
 
@@ -12928,9 +12930,9 @@ Example:
    |     local = chunk3
    |     local = chunk4
    | }
-   | 
+   |
    | # ...
-   | 
+   |
    | dist_threads = 4
 
 12.4.27. binlog_path

--- a/doc/sphinx.xml
+++ b/doc/sphinx.xml
@@ -38,13 +38,13 @@ does not depend on nor require any specific database to function.
 </para>
 <para>
 Applications can access Sphinx search daemon (searchd) using any of
-the three different access methods: a) via Sphinx own implementation of MySQL 
+the three different access methods: a) via Sphinx own implementation of MySQL
 network protocol (using a small SQL subset called SphinxQL, this is recommended
 way), b) via native search API (SphinxAPI) or c) via MySQL server with a
 pluggable storage engine (SphinxSE).
 </para>
 <para>
-Official native SphinxAPI implementations for PHP, Perl, Python, Ruby and Java 
+Official native SphinxAPI implementations for PHP, Perl, Python, Ruby and Java
 are included within the distribution package. API is very lightweight
 so porting it to a new language is known to take a few hours or days.
 Third party API ports and plugins exist for Perl, C#, Haskell,
@@ -236,8 +236,8 @@ during last years, the obvious decision is to continue developing Sphinx
 
 <sect1 id="supported-system"><title>Supported systems</title>
 <para>
-Sphinx can be compiled either from source or installed using prebuilt 
-packages. Most modern UNIX systems with a C++ compiler should be able 
+Sphinx can be compiled either from source or installed using prebuilt
+packages. Most modern UNIX systems with a C++ compiler should be able
 to compile and run Sphinx without any modifications.
 </para>
 <para>
@@ -372,7 +372,7 @@ do not seem to help you, please don't hesitate to contact me.
 <para>PPA repository (Ubuntu only).</para>
 <para>Installing Sphinx is much easier from Sphinxsearch PPA repository, because you will get all dependencies and can also update Sphinx to the latest version with the same command.</para>
 <orderedlist>
-<listitem>    
+<listitem>
     <para>First, add Sphinxsearch repository and update the list of packages:</para>
     <para><userinput>$ sudo add-apt-repository ppa:builds/sphinxsearch-rel23</userinput></para>
     <para><userinput>$ sudo apt-get update</userinput></para></listitem>
@@ -385,7 +385,7 @@ do not seem to help you, please don't hesitate to contact me.
 </sect1>
 
 <sect1 id="installing-redhat"><title>Installing Sphinx packages on RedHat and CentOS</title>
-<para>Currently we distribute Sphinx RPMS and SRPMS on our website for both 5.x and 6.x 
+<para>Currently we distribute Sphinx RPMS and SRPMS on our website for both 5.x and 6.x
 versions of Red Hat Enterprise Linux, but they can be installed on CentOS as well.</para>
 <orderedlist>
 <listitem>
@@ -484,7 +484,7 @@ possible that someone may use it. And now we're urging you: don't use it.
 The default value is 'inline' and it's a new standard. 'plain' hit_format
 is obsolete and will be removed in the near future.</para></listitem>
 <listitem><para>docinfo=inline is deprecated. You can now use
-<link linkend="conf-ondisk-attrs">ondisk_attrs</link> or 
+<link linkend="conf-ondisk-attrs">ondisk_attrs</link> or
 <link linkend="conf-ondisk-attrs-default">ondisk_attrs_default</link> instead.</para>
 </listitem>
 <listitem><para>workers=threads is a new default for all OS now.
@@ -755,6 +755,7 @@ Attributes are <emphasis>not</emphasis> full-text indexed; they are stored in th
 Currently supported attribute types are:
 <itemizedlist>
 <listitem><para>unsigned integers (1-bit to 32-bit wide);</para></listitem>
+<listitem><para>signed big integers (64-bit wide);</para></listitem>
 <listitem><para>UNIX timestamps;</para></listitem>
 <listitem><para>floating point values (32-bit, IEEE 754 single precision);</para></listitem>
 <listitem><para><link linkend="conf-sql-attr-string">strings</link> (since 1.10-beta);</para></listitem>
@@ -2587,7 +2588,7 @@ atc = log(1+sum(pair_tc))
 Note that this final dampening logarithm is exactly the reason you should use
 OPTION idf=plain, because without it, the expression inside the log() could be negative.
 </para><para>
-Having closer keyword occurrences actually contributes <emphasis>much</emphasis> more 
+Having closer keyword occurrences actually contributes <emphasis>much</emphasis> more
 to ATC than having more frequent keywords. Indeed, when the keywords are right next to
 each other, distance=1 and k=1; when there just one word in between them, distance=2 and
 k=0.297, with two words between, distance=3 and k=0.146, and so on. At the same time
@@ -3192,10 +3193,10 @@ LENGTH(json_attr.some_array) returns number of elements in array.
 <term id="expr-func-packedfactors">PACKEDFACTORS()</term>
 <listitem>
 <para>
-PACKEDFACTORS(), introduced in version 2.1.1-beta, can be used in queries, 
+PACKEDFACTORS(), introduced in version 2.1.1-beta, can be used in queries,
 either to just see all the weighting factors calculated when doing the matching, or to
 provide a binary attribute that can be used to write a custom ranking UDF.
-This function works only if expression ranker is specified and the query 
+This function works only if expression ranker is specified and the query
 is not a full scan, otherwise it will return an error. Starting with 2.2.2-beta
 PACKEDFACTORS() can take an optional argument that disables ATC ranking factor calculation:
 <programlisting>
@@ -3279,7 +3280,7 @@ WHERE match('hello')
 ORDER BY r DESC
 OPTION ranker=expr('1');
 </programlisting>
-Where CUSTOM_RANK() is a function implemented in an UDF. It should declare a 
+Where CUSTOM_RANK() is a function implemented in an UDF. It should declare a
 SPH_UDF_FACTORS structure (defined in <filename>sphinxudf.h</filename>), initialize this structure,
 unpack the factors into it before usage, and deinitialize it afterwards, as follows:
 <programlisting>
@@ -3336,7 +3337,7 @@ it technically feasible to implement additional re-ranking pass
 If used with SphinxQL but not called from any UDFs, the result of PACKEDFACTORS()
 is simply formatted as plain text, which can be used to manually assess the ranking
 factors. Note that this feature is not currently supported by the Sphinx API.
-</para>	
+</para>
 </listitem>
 </varlistentry>
 
@@ -4173,7 +4174,7 @@ is able to import standard C header, and emit standard dynamic libraries with
 properly exported functions. Of course, the path of least resistance is to write
 in either C++ or plain C. We provide an example UDF library written in plain C
 and implementing several functions (demonstrating a few different techniques)
-along with our source code, see 
+along with our source code, see
 <ulink url="https://github.com/sphinxsearch/sphinx/blob/master/src/udfexample.c">src/udfexample.c</ulink>.
 That example includes
 <ulink url="https://github.com/sphinxsearch/sphinx/blob/master/src/sphinxudf.h">src/sphinxudf.h</ulink>
@@ -5204,8 +5205,8 @@ is useful when you want to check your index before actually using it.
 <filename>wordbreaker</filename> is one of the helper tools within
 the Sphinx package, introduced in version 2.1.1-beta. It is used to
 split compound words, as usual in URLs, into its component words.
-For example, this tool can split "lordoftherings" into its four 
-component words, or "http://manofsteel.warnerbros.com" into "man 
+For example, this tool can split "lordoftherings" into its four
+component words, or "http://manofsteel.warnerbros.com" into "man
 of steel warner bros". This helps searching, without requiring
 prefixes or infixes: searching for "sphinx" wouldn't match "sphinxsearch"
 but if you break the compound word and index the separate components,
@@ -5225,16 +5226,16 @@ the splitting functionality.
 <para>Wordbreaker
 Wordbreaker needs a dictionary to recognize individual substrings within a string. To
 differentiate between different guesses, it uses the relative frequency of each
-word in the dictionary: higher frequency means higher split probability. You can 
+word in the dictionary: higher frequency means higher split probability. You can
 generate such a file using the <filename>indexer</filename> tool, as in
 <programlisting>
-indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.conf   
+indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.conf
 </programlisting>
 which will write the 100,000 most frequent words, along with their counts, from
 myindex into dict.txt. The output file is a text file, so you can edit it by hand,
 if need be, to add or remove words.
 </para>
-<para>See 
+<para>See
 <ulink url="http://sphinxsearch.com/blog/2013/01/29/a-new-tool-in-the-trunk-wordbreaker/">
 http://sphinxsearch.com/blog/2013/01/29/a-new-tool-in-the-trunk-wordbreaker/</ulink>
 for more on this tool.
@@ -5504,7 +5505,7 @@ OPTION &lt;optionname&gt;=&lt;value&gt; [ , ... ]
 </programlisting>
 Supported options and respectively allowed values are:
 <itemizedlist>
-<listitem><para>'agent_query_timeout' - integer (max time in milliseconds to wait for remote queries to complete, 
+<listitem><para>'agent_query_timeout' - integer (max time in milliseconds to wait for remote queries to complete,
 see <link linkend="conf-agent-query-timeout">agent_query_timeout</link> under Index configuration options for details)</para></listitem>
 <listitem><para>'boolean_simplify' - 0 or 1, enables simplifying the query to speed it up</para></listitem>
 <listitem><para>'comment' - string, user comment that gets copied to a query log file</para></listitem>
@@ -5711,7 +5712,7 @@ SHOW META [ LIKE pattern ]
 </programlisting>
 <para><b>SHOW META</b> shows additional meta-information about the latest
 query such as query time and keyword statistics. IO and CPU counters will only be available if searchd was started with --iostats and --cpustats switches respectively.
-Additional predicted_time, dist_predicted_time, [{local|dist}]_fetched_[{docs|hits|skips}] counters will only be available if searchd was configured with  
+Additional predicted_time, dist_predicted_time, [{local|dist}]_fetched_[{docs|hits|skips}] counters will only be available if searchd was configured with
 <link  linkend="conf-predicted-time-costs">predicted time costs</link> and query  had  predicted_time in OPTION clause.
 <programlisting>
 mysql> SELECT * FROM test1 WHERE MATCH('test|one|two');
@@ -6552,7 +6553,7 @@ added in 2.2.2-beta.
 Implementation details. As of 2.2.1-beta, the querying of an index is
 impossible (because of a write lock) while adding a column. This may change
 in the future. The newly created attribute values are set to 0. ALTER will
-not work for distributed indexes and indexes without any attributes. 
+not work for distributed indexes and indexes without any attributes.
 DROP COLUMN will fail if an index has only one attribute.
 </para>
 <programlisting>
@@ -8417,8 +8418,8 @@ star-syntax available in queries.
 <varlistentry>
     <term>"before_match":</term>
     <listitem><para>A string to insert before a keyword match. Starting with version 1.10-beta,
-    a %PASSAGE_ID% macro can be used in this string. The first match of the macro is replaced 
-    with an incrementing passage number within a current snippet. Numbering starts at 1 
+    a %PASSAGE_ID% macro can be used in this string. The first match of the macro is replaced
+    with an incrementing passage number within a current snippet. Numbering starts at 1
     by default but can be overridden with "start_passage_id" option. In a multi-document call,
     %PASSAGE_ID% would restart at every given document. Default is "&lt;b&gt;".</para></listitem>
 </varlistentry>
@@ -11437,7 +11438,7 @@ control character mapping.
 # default are English and Russian letters
 charset_table = 0..9, A..Z-&gt;a..z, _, a..z, \
     U+410..U+42F-&gt;U+430..U+44F, U+430..U+44F, U+401->U+451, U+451
-	
+
 # english charset defined with alias
 charset_table = 0..9, english, _
 </programlisting>
@@ -14443,8 +14444,8 @@ The last defined in distributed (network) indexes, or also may be overrided per-
 
 <sect2 id="conf-agent-retry-count"><title>agent_retry_count</title>
 <para>
-Integer, specifies how many times sphinx will try to connect and query remote agents in distributed index before reporting 
-fatal query error. Default is 0 (i.e. no retries). This value may be also specified on per-query basis using 
+Integer, specifies how many times sphinx will try to connect and query remote agents in distributed index before reporting
+fatal query error. Default is 0 (i.e. no retries). This value may be also specified on per-query basis using
 'OPTION retry_count=XXX' clause. If per-query option exists, it will override the one specified in config.
 </para>
 </sect2>
@@ -14452,8 +14453,8 @@ fatal query error. Default is 0 (i.e. no retries). This value may be also specif
 <sect2 id="conf-agent-retry-delay"><title>agent_retry_delay</title>
 <para>
 Integer, in milliseconds. Specifies the delay sphinx rest before retrying to query a remote agent in case it fails.
-The value has sense only if non-zero <link linkend="conf-agent-retry-count">agent_retry_count</link> 
-or non-zero per-query OPTION retry_count specified. Default is 500. This value may be also specified 
+The value has sense only if non-zero <link linkend="conf-agent-retry-count">agent_retry_count</link>
+or non-zero per-query OPTION retry_count specified. Default is 500. This value may be also specified
 on per-query basis using 'OPTION retry_delay=XXX' clause. If per-query option exists, it will override the one specified in config.
 </para>
 </sect2>
@@ -15123,7 +15124,7 @@ plugin_dir = /usr/local/sphinx/lib
   <listitem><para>fixed #1799, crash in queries to distributed indexes with <link linkend="sphinxql-select">GROUP BY</link> on multiple values</para></listitem>
   <listitem><para>fixed #1718, <option>expand_keywords</option> option lost in disk chunks of RT indexes</para></listitem>
   <listitem><para>fixed documentation on <link linkend="conf-rt-flush-period">rt_flush_period</link></para></listitem>
-  <listitem><para>fixed network protocol issue which results in timeouts of <filename>libmysqlclient</filename> for big Sphinx responses</para></listitem>  
+  <listitem><para>fixed network protocol issue which results in timeouts of <filename>libmysqlclient</filename> for big Sphinx responses</para></listitem>
 </itemizedlist>
 </sect1>
 
@@ -15163,7 +15164,7 @@ plugin_dir = /usr/local/sphinx/lib
   <listitem><para>added <link linkend="ref-indextool">indextool</link> <option>--fold</option> command and <option>-q</option> switch</para></listitem>
   <listitem><para>added JSON debug check for RT index RAM chunk</para></listitem>
   <listitem><para>added <link linkend="expr-func-length">LENGTH()</link> function for MVA</para></listitem>
-  <listitem><para>added missing <link linkend="conf-rt-attr-bool">rt_attr_bool</link> directive</para></listitem> 
+  <listitem><para>added missing <link linkend="conf-rt-attr-bool">rt_attr_bool</link> directive</para></listitem>
   <listitem><para>added support for selecting over 250 columns via SphinxQL</para></listitem>
   <listitem><para>deprecated custom sort mode, and <option>str2ordinal</option> and <option>str2wordcount</option> attribute types</para></listitem>
   <listitem><para>optimized <code>SELECT</code>, <code>UPDATE</code> for indexes with many attributes (up to 3.5x speedup in extreme cases)</para></listitem>
@@ -15212,7 +15213,7 @@ plugin_dir = /usr/local/sphinx/lib
   <listitem><para>fixed #1439, filters on float values in JSON issue, string values quoting issue</para></listitem>
   <listitem><para>fixed #1399, filter error message on string attribute</para></listitem>
   <listitem><para>fixed #1384, added possibility to define any own DSN line with <link linkend="confgroup-source">source=mssql</link> (like as in <code>source=odbc</code>)</para></listitem>
-  <listitem><para>fixed <link linkend="sphinxql-attach-index">ATTACH</link> vs wordforms or stopwords; after daemon was restarted this setting was getting lost in RT indexes</para></listitem>  
+  <listitem><para>fixed <link linkend="sphinxql-attach-index">ATTACH</link> vs wordforms or stopwords; after daemon was restarted this setting was getting lost in RT indexes</para></listitem>
   <listitem><para>fixed balancing of agents in HA</para></listitem>
   <listitem><para>fixed co-working of <code>index_exact_word</code> + AOT lemmatizer</para></listitem>
   <listitem><para>fixed epoll invoking and turned on by default</para></listitem>
@@ -15226,7 +15227,7 @@ plugin_dir = /usr/local/sphinx/lib
   <listitem><para>fixed rotation of global IDF for <option>workers=threads</option> and <option>seamless_rotate=1</option></para></listitem>
   <listitem><para>fixed rotation of old indexes</para></listitem>
   <listitem><para>fixed RT kill list survives <code>TRUNCATE</code> and works in newly <code>ATTACH</code>ed index</para></listitem>
-  <listitem><para>fixed saving id32 RT index with id64 daemon</para></listitem>  
+  <listitem><para>fixed saving id32 RT index with id64 daemon</para></listitem>
   <listitem><para>fixed stemmer vs RT index <code>INSERT</code></para></listitem>
   <listitem><para>fixed string case error with JSON attributes in select list of a query</para></listitem>
   <listitem><para>fixed <code>TOP_COUNT</code> usage in <filename>misc/suggest</filename> and updated to PHP 5.3 and UTF-8</para></listitem>


### PR DESCRIPTION
Remove useless trailing whitespaces in the meantime.

Note: doc/sphinx.txt and doc/sphinx.html use iso-8859-1 encoding.
