### PR TITLE
support changing tokens in morph plugins

### DIFF
--- a/src/sphinxquery.cpp
+++ b/src/sphinxquery.cpp
@@ -1118,6 +1118,10 @@ int XQParser_t::GetToken ( YYSTYPE * lvalp )
 			if ( m_bEmptyStopword )
 				m_iAtomPos--;
 		}
+		else
+		{
+			sToken = (const char *)sTmp;
+		}
 
 		if ( bMultiDest && !bMultiDestHead )
 		{


### PR DESCRIPTION
Currently pre/post morph plugins cannot change the searched tokens since they get a local copy of the token (sTmp) which is only used to determine whether the token word exists or not. Assuming the token word exists in the dictionary, the code uses the original sToken as the searched keyword.
This patch simply makes sToken point to the local sTmp variable (which is controllable from a morph plugin) when the word exists.
When a morph plugin is not present, sTmp is the same as sToken (it is copied from it a few lines above) and this change has no effect.