### PR TITLE
fix of #mantis-2590 to use regular merge at optimize

### DIFF
--- a/src/sphinxutils.cpp
+++ b/src/sphinxutils.cpp
@@ -2429,7 +2429,7 @@ void sphConfigureCommon ( const CSphConfig & hConf )
 	g_sLemmatizerBase = hCommon.GetStr ( "lemmatizer_base" );
 	sphConfigureRLP ( hCommon );
 
-	g_bProgressiveMerge = ( hCommon.GetInt ( "progressive_merge", 1 )!=0 );
+	g_bProgressiveMerge = ( hCommon.GetInt ( "progressive_merge", 0 )!=0 );
 
 	bool bJsonStrict = false;
 	bool bJsonAutoconvNumbers;


### PR DESCRIPTION
new feature progressive merge enabled by default seems producing bad meta for RT index after OPTIMIZE command that will be fixed.
However for now it might be better to disable that feature that enabled by default.

Also anyone might disable it by setting progressive_merge = 0 at common section of searchd