### PR TITLE
fix zonespanlist() function on distributed index

### DIFF
--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -8257,6 +8257,7 @@ void SearchHandler_c::RunSubset ( int iStart, int iEnd )
 			pLocalSorter = sphCreateQueue ( tQueueSettings );
 
 			uLocalPFFlags = tQueueSettings.m_uPackedFactorFlags;
+			m_dQueries[iStart].m_bZSlist = tQueueSettings.m_bZonespanlist;
 			if ( pExtraSchemaMT )
 				pExtraSchemaMT->Release();
 		}


### PR DESCRIPTION
When searching on a distributed index containing multiple local indices, and the conditions for reusing sorter are met, the sorter is created and stored at line searchd.cpp:8257:
   ` pLocalSorter = sphCreateQueue ( tQueueSettings );`
Then the local variable `tQueueSettings` leaves the '`if`' block and disappears, together with its `m_uPackedFactorFlags` member, whose value was not stored anywhere. This leads to `CSphQuery::m_bZSlist` being false regardless `zonespanlist()` function presence in the query. As a result, garbage or crashes take place of the expected zone lists.