### PR TITLE
send request in one time read to improve performance

### DIFF
--- a/api/libsphinxclient/test.c
+++ b/api/libsphinxclient/test.c
@@ -16,6 +16,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #if _WIN32
 #include <winsock2.h>
@@ -405,7 +406,7 @@ void title ( const char * name )
 	if ( g_smoke || !name )
 		return;
 
-	printf ( "-> % s <-\n\n", name );
+	printf ( "-> %s <-\n\n", name );
 }
 
 int main ( int argc, char ** argv )


### PR DESCRIPTION
the c version client write 2 times for request, the first write the header, the second write the load.
but it cause net_get_response to block about 40ms to read the header, the root cause may in the server side, but write in one time can remove the block, improve the performance from about 25 to about 4000 QPS in my machine. 